### PR TITLE
Add categoryOrder option so categories will be render in that order rather than the default one.

### DIFF
--- a/snippets/with_all_category_order.js
+++ b/snippets/with_all_category_order.js
@@ -1,0 +1,29 @@
+// if you don't specify a html file, the sniper will generate a div
+var app = require("ProtVista");
+var instance = new app({
+    el: yourDiv
+    , uniprotacc : 'P05067'
+    , categoryOrder: ['MOLECULE_PROCESSING','PTM', 'SEQUENCE_INFORMATION', 'STRUCTURAL', 'TOPOLOGY'
+        , 'MUTAGENESIS', 'PROTEOMICS', 'DOMAINS_AND_SITES', 'VARIATION']
+});
+//P05067 most of the times, P21802 has a deletion
+
+var input = d3.select('body').append('div');
+input.append('span').text('FtType: ');
+input.append('input').attr('type', 'text').attr('id', 'ftType');
+input.append('span').text('Begin: ');
+input.append('input').attr('type', 'text').attr('id', 'ftBegin');
+input.append('span').text('End: ');
+input.append('input').attr('type', 'text').attr('id', 'ftEnd');
+input.append('span').text('AltSeq: ');
+input.append('input').attr('type', 'text').attr('id', 'atlSeq');
+input.append('button').text('Select')
+    .on('click', function() {
+        var altSeq = d3.select('#atlSeq').node().value.toUpperCase();
+        altSeq = altSeq.length === 0 ? undefined : altSeq;
+        instance.selectFeature(
+            d3.select('#ftType').node().value.toUpperCase(),
+            d3.select('#ftBegin').node().value,
+            d3.select('#ftEnd').node().value,
+            altSeq);
+    });

--- a/snippets/with_some_category_order.js
+++ b/snippets/with_some_category_order.js
@@ -1,0 +1,28 @@
+// if you don't specify a html file, the sniper will generate a div
+var app = require("ProtVista");
+var instance = new app({
+    el: yourDiv
+    , uniprotacc : 'P05067'
+    , categoryOrder: ['DOMAINS_AND_SITES', 'VARIATION', 'PTM']
+});
+//P05067 most of the times, P21802 has a deletion
+
+var input = d3.select('body').append('div');
+input.append('span').text('FtType: ');
+input.append('input').attr('type', 'text').attr('id', 'ftType');
+input.append('span').text('Begin: ');
+input.append('input').attr('type', 'text').attr('id', 'ftBegin');
+input.append('span').text('End: ');
+input.append('input').attr('type', 'text').attr('id', 'ftEnd');
+input.append('span').text('AltSeq: ');
+input.append('input').attr('type', 'text').attr('id', 'atlSeq');
+input.append('button').text('Select')
+    .on('click', function() {
+        var altSeq = d3.select('#atlSeq').node().value.toUpperCase();
+        altSeq = altSeq.length === 0 ? undefined : altSeq;
+        instance.selectFeature(
+            d3.select('#ftType').node().value.toUpperCase(),
+            d3.select('#ftBegin').node().value,
+            d3.select('#ftEnd').node().value,
+            altSeq);
+    });

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -80,6 +80,21 @@ var Constants = function() {
     setCategoryNamesInOrder: function(categories) {
         allCategories = categories;
     },
+    setOrderForCategoryNames: function(categoryNames) {
+        var orderedCategories = [];
+        _.each(categoryNames, function(name) {
+            var position = 0;
+            var category = _.find(allCategories, function(cat, index) {
+                position = index;
+                return cat.name.toUpperCase() === name.toUpperCase();
+            });
+            if (category) {
+                orderedCategories.push(category);
+                allCategories.splice(position, 1);
+            }
+        });
+        allCategories = orderedCategories.concat(allCategories);
+    },
     convertNameToLabel: function(name) {
         var label = name.replace(/_/g, ' ');
         label = label.charAt(0).toUpperCase() + label.slice(1).toLowerCase();

--- a/src/FeaturesViewer.js
+++ b/src/FeaturesViewer.js
@@ -495,6 +495,9 @@ var FeaturesViewer = function(opts) {
             delegates.push(delegate);
         });
 
+        if (opts.categoryOrder) {
+            Constants.setOrderForCategoryNames(opts.categoryOrder);
+        }
         if (opts.customConfig) {
             var configLoader = DataLoader.get(opts.customConfig);
             configLoader.done(function(d) {


### PR DESCRIPTION
The new "categoryOrder" instantiation option allows defining a rendering order for categories. Any visible category not mentioned in the array will be render after the last in the list following the default order.

The option "customConfig" allows to define order, change label and description of categories. "customConfig" has a higher priority so if both "categoryOrder" and "customConfig" used only the latter will be taken into account. "categoryOrder" is just a shortcut, an easy way to define order.

All this will go to documentation.

