### PR TITLE
Adding themes (and other vis improvements)

### DIFF
--- a/less/fv-theme-grey.less
+++ b/less/fv-theme-grey.less
@@ -1,9 +1,4 @@
-/*
-specific colours
-*/
-@c_helix:  #FF0066;
-@c_strand: #FFCC00;
-@c_turn:   #0571AF;
+@import "includes/defaults";
 
 /*
 d3.scale.category20()
@@ -29,15 +24,67 @@ d3.scale.category20()
 @c19: #17becf;
 @c20: #9edae5;
 
+@c_chain:    @c1;
+@c_transit:  @c2;
+@c_init_met: @c3;
+@c_propep:   @c4;
+@c_peptide:  @c5;
+@c_signal:   @c6;
+@c_turn:     @c7;
+@c_strand:   @c8;
+@c_helix:    @c9;
+@c_crosslnk: @c10;
+@c_disulfid: @c11;
+@c_region:   @c12;
+@c_coiled:   @c13;
+@c_motif:    @c14;
+@c_repeat:   @c15;
+@c_ca_bind:  @c16;
+@c_dna_bind: @c17;
+@c_domain:   @c18;
+@c_zn_fing:  @c19;
+@c_np_bind:  @c20;
+@c_metal:    @c1;
+@c_site:     @c2;
+@c_binding:  @c3;
+@c_act_site: @c4;
+@c_mod_res:  @c5;
+@c_lipid:    @c6;
+@c_carbohyd: @c7;
+@c_compbias: @c8;
+@c_mutagen:  @c9;
+@c_conflict: @c10;
+@c_non_cons: @c11;
+@c_non_ter:  @c12;
+@c_unsure:   @c13;
+@c_non_std:  @c14;
+@c_topo_dom: @c15;
+@c_transmem: @c16;
+@c_intramem: @c17;
+
 .pv-theme-grey {
   .up_pftv_navruler svg {
     background-color: transparent;
   }
 
   .up_pftv_buttons {
-    border: 1px solid #eee;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    text-align: center;
+  }
+  
+  .up_pftv_buttons span {
+    background-color: #eee;
+    border: 1px solid #ccc;
     border-radius: 3px 3px;
-    padding: 5px;
+    padding: 2px;
+    margin: 2px;
+  }
+
+  .up_pftv_buttons span:hover {
+    background-color: #fff;
+    border-color: #999;
   }
 
   .up_pftv_aaviewer .background, .up_pftv_viewport .background {
@@ -64,7 +111,8 @@ d3.scale.category20()
   }
 
   .up_pftv_category {
-    border-bottom-color: #ddd;
+    margin-bottom: 0;
+    border-bottom: 1px solid #ddd;
   }
 
   .up_pftv_category-name {
@@ -73,62 +121,57 @@ d3.scale.category20()
   }
 
   .up_pftv_category a:hover {
-      background-color: #eeeeee;
+      background-color: #ddd;
   }
 
   .up_pftv_track-header {
     background-color: #f3f3f3;  
     text-align: right;
-    text-transform: uppercase; 
+    text-transform: uppercase;
+    font-size: 12px;
+    font-style: italic;
   }
 
   .up_pftv_track {
     border-top: 1px solid #eee;
   }
 
+  .up_pftv_navruler path.trapezoid {
+  }
+
+  .up_pftv_container .up_pftv_navruler .axis .tick, .up_pftv_container .up_pftv_navruler .axis .domain {
+      stroke: black;
+  }
+  .up_pftv_container .up_pftv_navruler .axis text {
+      stroke: none;
+      fill: black;
+  }
+
+  .up_pftv_navruler .extent {
+      fill: steelblue;
+      stroke: none;
+  }
+
+  .up_pftv_navruler .handle {
+      fill: #eee;
+      fill-opacity: 1.0;
+      stroke: #999;
+      stroke-opacity: 1.0;
+      stroke-width: 1;
+  }
+
+  .up_pftv_navruler text.domain-label {
+    fill: black;
+  }
+
+  .up_pftv_navruler .handle:hover {
+      fill: #ccc;
+  }
+
   .up_pftv_disulphid {
   }
 
-  svg .up_pftv_chain             { stroke: @c1;  fill: @c1;  }
-  svg .up_pftv_transit           { stroke: @c2;  fill: @c2;  }
-  svg .up_pftv_init_met          { stroke: @c3;  fill: @c3;  }
-  svg .up_pftv_propep            { stroke: @c4;  fill: @c4;  }
-  svg .up_pftv_peptide           { stroke: @c5;  fill: @c5;  }
-  svg .up_pftv_signal            { stroke: @c6;  fill: @c6;  }
-  svg .up_pftv_crosslnk          { stroke: @c10; fill: @c10; }
-  svg .up_pftv_disulfid          { stroke: @c11; fill: @c11; }
-  svg .up_pftv_region            { stroke: @c12; fill: @c12; }
-  svg .up_pftv_coiled            { stroke: @c13; fill: @c13; }
-  svg .up_pftv_motif             { stroke: @c14; fill: @c14; }
-  svg .up_pftv_repeat            { stroke: @c15; fill: @c15; }
-  svg .up_pftv_ca_bind           { stroke: @c16; fill: @c16; }
-  svg .up_pftv_dna_bind          { stroke: @c17; fill: @c17; }
-  svg .up_pftv_domain            { stroke: @c18; fill: @c18; }
-  svg .up_pftv_zn_fing           { stroke: @c19; fill: @c19; }
-  svg .up_pftv_np_bind           { stroke: @c20; fill: @c20; }
-  svg .up_pftv_metal             { stroke: @c1;  fill: @c1; }
-  svg .up_pftv_binding           { stroke: @c2;  fill: @c2; }
-  svg .up_pftv_act_site          { stroke: @c3;  fill: @c3; }
-  svg .up_pftv_mod_res           { stroke: @c4;  fill: @c4; }
-  svg .up_pftv_lipid             { stroke: @c5;  fill: @c5; }
-  svg .up_pftv_carbohyd          { stroke: @c6;  fill: @c6; }
-  svg .up_pftv_variant           { stroke: @c7;  fill: @c7; }
-  svg .up_pftv_compbias          { stroke: @c8;  fill: @c8; }
-  svg .up_pftv_mutagen           { stroke: @c9;  fill: @c9; }
-  svg .up_pftv_conflict          { stroke: @c10; fill: @c10; }
-  svg .up_pftv_non_cons          { stroke: @c11; fill: @c11; }
-  svg .up_pftv_non_ter           { stroke: @c12; fill: @c12; }
-  svg .up_pftv_unsure            { stroke: @c13; fill: @c13; }
-  svg .up_pftv_non_std           { stroke: @c14; fill: @c14; }
-  svg .up_pftv_topo_dom          { stroke: @c15; fill: @c15; }
-  svg .up_pftv_transmem          { stroke: @c16; fill: @c16; }  
-  svg .up_pftv_intramem          { stroke: @c17; fill: @c17; }
-  svg .up_pftv_unique            { stroke: @c18; fill: @c18; }
-  svg .up_pftv_non_unique        { stroke: @c19; fill: @c19; }
-
-  svg .up_pftv_turn              { stroke: @c_turn;   fill: @c_turn; }
-  svg .up_pftv_strand            { stroke: @c_strand; fill: @c_strand; }
-  svg .up_pftv_helix             { stroke: @c_helix;  fill: @c_helix;  }
+  @svg_features();
 }
 
 

--- a/less/fv-theme-grey.less
+++ b/less/fv-theme-grey.less
@@ -34,6 +34,12 @@ d3.scale.category20()
     background-color: transparent;
   }
 
+  .up_pftv_buttons {
+    border: 1px solid #eee;
+    border-radius: 3px 3px;
+    padding: 5px;
+  }
+
   .up_pftv_aaviewer .background, .up_pftv_viewport .background {
     fill: white;
   }

--- a/less/includes/defaults.less
+++ b/less/includes/defaults.less
@@ -1,0 +1,86 @@
+@c_chain:   #CC9933;
+@c_transit: #009966;
+@c_init_met:  #996633;
+@c_propep: #99CCCC;
+@c_peptide: #006699;
+@c_signal: #CC0033;
+@c_turn: #0571AF;
+@c_strand: #FFCC00;
+@c_helix: #FF0066;
+@c_crosslnk: #FF6600;
+@c_disulfid: #23B14D;
+@c_region: #B33E00;
+@c_coiled: #006699;
+@c_motif: #402060;
+@c_repeat: #9900FF;
+@c_ca_bind: #FF3399;
+@c_dna_bind: #009933;
+@c_domain: #9999FF;
+@c_zn_fing: #990066;
+@c_np_bind: #FF9900;
+@c_metal: #009900;
+@c_site: #660033;
+@c_binding: #006699;
+@c_act_site: #FF6666;
+@c_mod_res: #000066;
+@c_lipid: #99CC33;
+@c_carbohyd: #CC3366;
+@c_compbias: #FF3366;
+@c_mutagen: #FF9900;
+@c_conflict: #6633CC;
+@c_non_cons: #FF0033;
+@c_non_ter: #339933;
+@c_unsure: #33FF00;
+@c_non_std: #330066;
+@c_topo_dom: #CC0000;
+@c_transmem: #CC00CC;
+@c_intramem: #0000CC;
+
+@c_variant: #fc3133;
+@c_unique: #fc3133;
+@c_non_unique: #8585fc;
+
+/* Features */
+@svg_features: {
+  svg .up_pftv_chain        { stroke: @c_chain;  fill: @c_chain;  }
+  svg .up_pftv_transit      { stroke: @c_transit; fill: @c_transit; }
+  svg .up_pftv_init_met     { stroke: @c_init_met; fill: @c_init_met; }
+  svg .up_pftv_propep       { stroke: @c_propep; fill: @c_propep; }
+  svg .up_pftv_peptide      { stroke: @c_peptide; fill: @c_peptide; }
+  svg .up_pftv_signal       { stroke: @c_signal; fill: @c_signal; }
+  svg .up_pftv_crosslnk     { stroke: @c_crosslnk; fill: @c_crosslnk; }
+  svg .up_pftv_disulfid     { stroke: @c_disulfid; fill: @c_disulfid; }
+  svg .up_pftv_region       { stroke: @c_region; fill: @c_region; }
+  svg .up_pftv_coiled       { stroke: @c_coiled; fill: @c_coiled; }
+  svg .up_pftv_motif        { stroke: @c_motif; fill: @c_motif; }
+  svg .up_pftv_repeat       { stroke: @c_repeat; fill: @c_repeat; }
+  svg .up_pftv_ca_bind      { stroke: @c_ca_bind; fill: @c_ca_bind; }
+  svg .up_pftv_dna_bind     { stroke: @c_dna_bind; fill: @c_dna_bind; }
+  svg .up_pftv_domain       { stroke: @c_domain; fill: @c_domain; }
+  svg .up_pftv_zn_fing      { stroke: @c_zn_fing; fill: @c_zn_fing; }
+  svg .up_pftv_np_bind      { stroke: @c_np_bind; fill: @c_np_bind; }
+  svg .up_pftv_metal        { stroke: @c_metal; fill: @c_metal; }
+  svg .up_pftv_binding      { stroke: @c_binding; fill: @c_binding; }
+  svg .up_pftv_act_site     { stroke: @c_act_site; fill: @c_act_site; }
+  svg .up_pftv_mod_res      { stroke: @c_mod_res; fill: @c_mod_res; }
+  svg .up_pftv_lipid        { stroke: @c_lipid; fill: @c_lipid; }
+  svg .up_pftv_carbohyd     { stroke: @c_carbohyd; fill: @c_carbohyd; }
+  svg .up_pftv_variant      { stroke: @c_variant; fill: @c_variant; }
+  svg .up_pftv_compbias     { stroke: @c_compbias; fill: @c_compbias; }
+  svg .up_pftv_mutagen      { stroke: @c_mutagen; fill: @c_mutagen; }
+  svg .up_pftv_conflict     { stroke: @c_conflict; fill: @c_conflict; }
+  svg .up_pftv_non_cons     { stroke: @c_non_cons; fill: @c_non_cons; }
+  svg .up_pftv_non_ter      { stroke: @c_non_ter; fill: @c_non_ter; }
+  svg .up_pftv_unsure       { stroke: @c_unsure; fill: @c_unsure; }
+  svg .up_pftv_non_std      { stroke: @c_non_std; fill: @c_non_std; }
+  svg .up_pftv_topo_dom     { stroke: @c_topo_dom; fill: @c_topo_dom; }
+  svg .up_pftv_transmem     { stroke: @c_transmem; fill: @c_transmem; }  
+  svg .up_pftv_intramem     { stroke: @c_intramem; fill: @c_intramem; }
+  svg .up_pftv_unique       { stroke: @c_unique; fill: @c_unique; }
+  svg .up_pftv_non_unique   { stroke: @c_non_unique; fill: @c_non_unique; }
+
+  svg .up_pftv_turn         { stroke: @c_turn;   fill: @c_turn; }
+  svg .up_pftv_strand       { stroke: @c_strand; fill: @c_strand; }
+  svg .up_pftv_helix        { stroke: @c_helix;  fill: @c_helix; }  
+};
+

--- a/less/main.less
+++ b/less/main.less
@@ -1,0 +1,538 @@
+@import "includes/defaults";
+
+.up_pftv_container svg {
+    overflow: hidden;
+}
+
+.up_pftv_container rect {
+  shape-rendering: crispEdges;
+}
+
+.up_pftv_buttons {
+    display: inline-block;
+    padding: 0 .5em 0 .5em;
+    width: 180px;
+    text-align: right;
+    vertical-align: bottom;
+    position: relative;
+}
+
+.up_pftv_buttons a {
+    color: inherit;
+    text-decoration: none;
+}
+.up_pftv_buttons > span {
+    cursor: pointer;
+    font-size: 18px;
+    opacity: 0.8;
+}
+
+.up_pftv_buttons > span:hover {
+    opacity: 1;
+}
+
+.up_pftv_category-container {
+    position: relative;
+    border-right: 2px solid #b2f5ff;
+    border-top: 1px solid #b2f5ff;
+}
+
+.up_pftv_category-container svg {
+    cursor: move;
+}
+
+.up_pftv_container {
+    position: relative;
+    width: 960px;
+    color:#557071 !important;
+    font-family: 'Helvetica neue', Helvetica, Arial, sans-serif !important;
+    font-size: 13px !important;
+    line-height: 1.5 !important;
+}
+
+.up_pftv_row {
+  width: 100%;
+  clear: both;
+  padding: 0;
+}
+.up_pftv_mainpanel {
+  margin-left: 200px;
+  padding: 0;
+}
+.up_pftv_leftpanel {
+  float: left;
+  width: 200px;
+  padding: 0;
+}
+
+.up_pftv_category-name {
+  padding: 0;
+}
+
+.up_pftv_container a {
+  color:#557071 !important;
+  border:none !important;
+}
+
+.up_pftv_container h4 {
+  font-size: 1em !important;
+  font-weight: 500 !important;
+  border-bottom: 1px solid #cacaca;
+  margin-bottom: .7em;
+}
+
+.up_pftv_keepWithPrevious {
+    margin-top: 0px;
+}
+
+.up_ptfv_pp-container {
+    display: inline-block;
+    margin: 5em 0 0 0.5em;
+    vertical-align: top;
+}
+
+.up_pftv_navruler svg {
+    vertical-align: bottom;
+    font-size: 14px;
+}
+
+.up_pftv_aaviewer .background, .up_pftv_viewport .background {
+  fill: white;
+}
+
+/*Category and type tracks*/
+.up_pftv_category {
+    margin-bottom: .1em;
+    border-bottom: .1em solid #b2f5ff;
+}
+
+.up_pftv_category-name, .up_pftv_track-header {
+    font-weight: 400;
+    vertical-align: bottom;
+    display: block;
+    border: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    height: 40px;
+    line-height: 40px;
+    padding: 0 5px; 
+}
+
+.up_pftv_category-name {
+    background-color: #b2f5ff;
+}
+.up_pftv_track-header {
+}
+
+.up_pftv_category a:hover {
+    background-color: #80EEFF;
+    text-decoration: none;
+}
+
+.up_pftv_track-header {
+    background-color: #d9faff;
+}
+
+.up_pftv_navruler .extent {
+    fill: #ccc;
+    stroke: none;
+}
+
+.up_pftv_navruler .handle {
+    fill: #999;
+    fill-opacity: 1.0;
+    stroke: #999;
+    stroke-opacity: 1.0;
+    stroke-width: 1;
+}
+
+.up_pftv_category-viewer, .up_pftv_track, .up_pftv_aaviewer {
+    position: relative;
+    display: inline-block;
+    vertical-align: bottom;
+    width: 760px;
+}
+
+.up_pftv_category-viewer svg, .up_pftv_track svg, .up_pftv_aaviewer svg {
+    vertical-align: bottom;
+}
+
+.up_pftv_category-name {
+    cursor: pointer;
+}
+
+.up_pftv_track-header-container {
+    vertical-align: top;
+    margin-top: 1px;
+    background-color: #D9FAFF;
+}
+
+.up_pftv_track {
+    border-top: 1px #b2f5ff solid;
+}
+
+.up_pftv_category-name.up_pftv_arrow-right:before {
+    content: ' ';
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-left: 5px solid #333;
+    margin-right: 5px;
+}
+
+.up_pftv_category-name.up_pftv_arrow-down:before {
+    content: ' ';
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid #333;
+    margin-right: 5px;
+}
+
+.up_pftv_category-disabled {
+    opacity: 0;
+    display: none;
+}
+
+/* Ruler */
+.up_pftv_container .axis {
+    font-size: 12px;
+}
+
+.up_pftv_container .axis line, .up_pftv_container .axis path {
+    fill: none;
+    stroke: #666;
+}
+
+.up_pftv_container .axis text {
+    fill: #666;
+}
+
+.up_pftv_navruler { pointer-events: none }
+
+.up_pftv_shadow, .up_pftv_amino_acid_selector {
+    fill: #FFE999;
+    fill-opacity: 1;
+}
+
+.fv-zoom-gradient-start {
+    stop-color: #eee;
+    stop-opacity: 1.0;
+}
+.fv-zoom-gradient-end {
+    stop-color: #eee;
+    stop-opacity: 1.0;
+}
+
+.up_pftv_aaviewer text {
+    font-family: "Lucida Console", Monaco, monospace;
+    font-size: 12px;
+}
+
+.up_pftv_feature {
+    cursor: pointer;
+    fill-opacity: .6;
+}
+
+.up_pftv_feature:hover {
+    fill-opacity: .9;
+}
+
+.up_pftv_activeFeature {
+    fill-opacity: .9 !important;
+}
+
+.up_pftv_variation-chart .up_pftv_block-area {
+    fill: #ccc;
+}
+
+.up_pftv_variation-chart .up_pftv_block-area:hover {
+    fill: #999;
+    cursor: pointer;
+}
+
+.up_pftv_variation-chart .up_pftv_line {
+    stroke: #999;
+    stroke-width: 1px;
+}
+
+.up_pftv_variation-chart .up_pftv_line:hover,  .up_pftv_variation-chart .up_pftv_line:hover + .up_pftv_block-area {
+    stroke: darkslategrey;
+    cursor: pointer;
+}
+
+/* Dialogs */
+
+.up_pftv_dialog-container {
+  margin:0;padding:0;
+}
+
+.up_pftv_dialog-container li a {
+  display: block;
+  line-height: 2em;
+  padding: 0 .2em;
+  cursor: pointer;
+}
+
+.up_pftv_legend {
+    vertical-align: sub;
+    width: 1.5em;
+    display: inline-block;
+    height: 1em;
+    border-radius: .4em;
+    border: 2px solid #ABABAB;
+    margin-right: .5em;
+}
+
+.up_pftv_legend_double {
+    height: 3em !important;
+}
+
+.up_pftv_legend_text {
+    font-size: 12px;
+    line-height: 2em;
+    display: inline-block;
+    vertical-align: top;
+}
+
+/* Close button */
+.up_pftv_tooltip-close {
+    color: #FFF;
+    background-color: #333333;
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    cursor: pointer;
+    border-radius: 20px;
+    width: 20px;
+    height: 20px;
+    font-size: 14px !important;
+    text-align: center;
+    border: 1px solid #fff;
+}
+
+/* Tooltip */
+.up_pftv_tooltip-pin-container {
+    display: inline-block;
+    float: left;
+    padding: 4px 10px 0 0;
+}
+
+.up_pftv_iconContainer-unpinned {
+    background-color: lightgrey !important;
+    color: black !important;
+}
+
+.up_pftv_iconContainer-unpinned:hover {
+    background-color: grey !important;
+}
+
+.up_pftv_iconContainer-pinned {
+    background-color: black !important;
+    color: white !important;
+}
+
+.up_pftv_tooltip-container, .up_pftv_popupDialog-container {
+    z-index: 50000;
+    position: absolute;
+    opacity: 0;
+    display: none;
+}
+
+.up_pftv_tooltip-container {
+    min-width: 220px;
+}
+
+.up_pftv_popupDialog-container {
+    border: 1px solid #557071;
+    background-color: #ffffff;
+    padding: 0.5em;
+    min-width: 210px;
+    text-align: left;
+    font-size: 13px;
+}
+
+.up_pftv_tooltip-container table {
+    font-size: 13px;
+    border: 2px solid #CCC;
+    border-spacing: 0;
+    border-collapse: collapse;
+    background-color: #FFF;
+    -webkit-box-shadow: 5px 5px 2px 0px rgba(0, 0, 0, 0.1);
+    -moz-box-shadow: 5px 5px 2px 0px rgba(0, 0, 0, 0.1);
+    box-shadow: 5px 5px 2px 0px rgba(0, 0, 0, 0.1);
+    width: 100%;
+}
+
+.up_pftv_tooltip-container table th {
+    text-transform: capitalize;
+    font-weight: 400;
+    white-space: nowrap;
+    letter-spacing: .05em;
+    font-size: 1.1em;
+    background-color: #595959;
+    line-height: 2em;
+    padding: 0 .7em;
+    color: #FFF;
+    text-align: center;
+}
+
+.up_pftv_tooltip-container table a {
+    text-decoration: underline !important;
+}
+
+.up_pftv_tooltip-container table td {
+    padding: .4em;
+    margin: 0;
+    border: 1px solid #CCC;
+}
+
+.up_pftv_tooltip-container td:first-child {
+    font-weight: bold;
+}
+
+.up_pftv_tooltip-container .up_pftv_evidence-col {
+    background-color: #FFF;
+}
+
+.up_pftv_tooltip-container .up_pftv_evidence-source {
+    background-color: #FFF;
+}
+
+.up_pftv_tooltip-container .up_pftv_section {
+    background-color: #B3B3B3;
+    text-align: center;
+}
+
+.up_pftv_tooltip-container .up_pftv_subsection {
+    color: black;
+}
+
+@svg_features();
+
+svg .up_pftv_variant {
+    stroke-width: 2;
+}
+
+svg .up_pftv_unique {
+    stroke: #fc3133;
+    fill: #fd5a5d;
+}
+
+svg .up_pftv_non_unique {
+    stroke: #8585fc;
+    fill: #5a60fb;
+}
+
+
+/* Variation */
+.up_pftv_variants-svg .axis path {
+    display: none;
+}
+
+.up_pftv_variants-svg .axis text {
+    font-size: 10px;
+    font-family: 'Helvetica neue', Helvetica, Arial, sans-serif;
+}
+
+.up_pftv_variants-svg .variation-y.axis line {
+    stroke: #ccc;
+    opacity: .4;
+}
+
+.up_pftv_variants-svg .variation-x.axis line {
+    stroke: #000;
+}
+
+.up_pftv_variants-svg circle.main-seq {
+    fill: #fff;
+    stroke: steelblue;
+    stroke-width: 1.5px;
+    /*display: none;*/
+}
+
+.up_pftv_variants-svg .main-sequence {
+    fill: green;
+}
+
+.up_pftv_variants-svg circle {
+    cursor: pointer;
+    fill-opacity: .6;
+}
+
+.up_pftv_variants-svg .up_pftv_variant_hidden {
+    cursor: default;
+    opacity: 0;
+}
+
+.up_pftv_variants-svg circle:hover {
+    fill-opacity: 0.9;
+}
+
+.up_pftv_dialog_checkboxLabel {
+    opacity: 0.9;
+}
+
+.up_pftv_dialog_checkboxLabel:hover {
+    cursor: pointer;
+    opacity: 1;
+}
+
+.up_pftv_message_wrapper {
+    margin: .7em;
+}
+
+/*Taken from http://www.karimnassar.com/code/web/css-icons/*/
+.up_pftv_icon, .up_pftv_icon::before, .up_pftv_icon::after
+{
+    position: relative;
+    padding: 0;
+    margin: 0;
+}
+
+.up_pftv_icon {
+    font-size: 20px;
+    color: transparent;
+}
+.up_pftv_icon.up_pftv_warning {
+    display: inline-block;
+    top: 0.225em;
+    width: 1.15em;
+    height: 1.15em;
+    overflow: hidden;
+    border: none;
+    background-color: transparent;
+    border-radius: 0.625em;
+}
+
+.up_pftv_icon.up_pftv_warning::before {
+    content: "";
+    display: block;
+    top: -0.08em;
+    left: 0.0em;
+    position: absolute;
+    border: transparent 0.6em solid;
+    border-bottom-color: #fd3;
+    border-bottom-width: 1em;
+    border-top-width: 0;
+    box-shadow: #999 0 1px 1px;
+}
+
+.up_pftv_icon.up_pftv_warning::after {
+    display: block;
+    position: absolute;
+    top: 0.3em;
+    left: 0;
+    width: 100%;
+    padding: 0 1px;
+    text-align: center;
+    content: "!";
+    font-size: 0.65em;
+    font-weight: bold;
+    color: #333;
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "gulp-gzip": "0.0.8",
     "gulp-istanbul": "^0.10.0",
     "gulp-jshint": "^1.8.4",
+    "gulp-less": "^3.0.0",
     "gulp-minify-css": "^1.2.0",
     "gulp-mocha": "^1.0.0",
     "gulp-mocha-phantomjs": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,9 @@
   },
   "sniper": {
     "js": [
-      "/build/protvista.js"
+      "/build/protvista.js",
+      "/node_modules/d3/d3.js",
+      "/node_modules/jquery/dist/jquery.min.js"
     ],
     "css": [
       "/build/css/main.css"

--- a/snippets/with_theme.js
+++ b/snippets/with_theme.js
@@ -1,0 +1,24 @@
+
+var app = require("ProtVista");
+
+var themeClassName = 'pv-theme-grey';
+
+var body = d3.select("body");
+
+// add container without theme
+body.append("h2").text("No Theme")
+body.append("div")
+    .attr("id", "app-no-theme")
+
+// add container with theme
+body.append("h2").text("With Theme")
+body.append("div")
+    .attr("id", "app-with-theme")
+    .attr("class", themeClassName);
+
+// app instance without theme
+var app1 = new app({el: document.getElementById('app-no-theme'), text: 'biojs', uniprotacc : 'P05067'});
+
+// app instance with theme
+var app2 = new app({el: document.getElementById('app-with-theme'), text: 'biojs', uniprotacc : 'P05067'});
+

--- a/snippets/with_theme.json
+++ b/snippets/with_theme.json
@@ -1,0 +1,3 @@
+{
+  "css": ["style/fv-theme-grey.css"]
+}

--- a/snippets/with_theme.json
+++ b/snippets/with_theme.json
@@ -1,3 +1,3 @@
 {
-  "css": ["style/fv-theme-grey.css"]
+  "css": ["build/css/fv-theme-grey.css"]
 }

--- a/src/CategoryFactory.js
+++ b/src/CategoryFactory.js
@@ -24,8 +24,11 @@ var Category = function(name, data, catInfo, fv, container) {
     category.categoryViewer = undefined;
 
     category.categoryContainer = container.append('div')
-        .attr('class', 'up_pftv_category');
-    category.header = category.categoryContainer.append('a')
+        .attr('class', 'up_pftv_row up_pftv_category');
+    
+    category.header = category.categoryContainer.append('div')
+        .attr('class', 'up_pftv_leftpanel')
+        .append('a')
         .attr('class', 'up_pftv_category-name up_pftv_arrow-right')
         .attr('title', category.name)
         .text(catInfo.label)
@@ -35,9 +38,13 @@ var Category = function(name, data, catInfo, fv, container) {
         });
 
     category.viewerContainer = category.categoryContainer.append('div')
+        .attr('class', 'up_pftv_mainpanel')
+        .append('div')
         .attr('class', 'up_pftv_category-viewer');
 
     category.tracksContainer = category.categoryContainer.append('div')
+        .attr('class', 'up_pftv_row')
+        .append('div')
         .attr('class', 'up_pftv_category-tracks')
         .style('display','none');
 };

--- a/src/DownloadDataLoader.js
+++ b/src/DownloadDataLoader.js
@@ -57,7 +57,7 @@ var DownloadDataLoader = function() {
                     zip.generateAsync({type:"base64"}).then(function (base64) {
                         window.location = "data:application/zip;base64," + base64;
                     }, function (err) {
-                        console.log('Error: ', err)
+                        console.log('Error: ', err);
                     });
                 }
             });

--- a/src/DownloadDialog.js
+++ b/src/DownloadDialog.js
@@ -10,7 +10,7 @@ var Constants = require("./Constants");
 var DownloadDataLoader = require("./DownloadDataLoader");
 
 var populateDialog = function (fv, wrapper) {
-    var isSafari = navigator.vendor.indexOf("Apple")==0 && /\sSafari\//.test(navigator.userAgent);
+    var isSafari = navigator.vendor.indexOf("Apple") === 0 && /\sSafari\//.test(navigator.userAgent);
 
     var selected = true;
     var allFormats = Constants.getExternalDataSource() === undefined

--- a/src/FeaturesViewer.js
+++ b/src/FeaturesViewer.js
@@ -617,19 +617,19 @@ FeaturesViewer.prototype.initLayout = function(opts, d) {
             closeTooltipAndPopup(fv);
         });
 
-    fv.header = fvContainer.append('div');
+    fv.header = fvContainer.append('div')
+      .classed('up_pftv_header up_pftv_row', true);
 
-    fv.container = fvContainer
-        .append('div')
-        .attr('class', 'up_pftv_category-container');
+    fv.container = fvContainer.append('div')
+      .classed('up_pftv_category-container', true);
 
     fv.ontheFlyContainer = fv.container.append('div').classed('up_pftv_category_on_the_fly', true);
 
     _.each(Constants.getCategoryNamesInOrder(), function(catInfo) {
-        fv.container.append('div').classed('up_pftv_category_' + catInfo.name, true);
+        fv.container.append('div').classed('up_pftv_category_row up_pftv_category_' + catInfo.name, true);
     });
 
-    fv.footer = fvContainer.append('div').attr('class','bottom-aa-container');
+    fv.footer = fvContainer.append('div').attr('class', 'up_pftv_footer up_pftv_row');
 };
 
 FeaturesViewer.prototype.loadZoom = function(d) {
@@ -640,14 +640,22 @@ FeaturesViewer.prototype.loadZoom = function(d) {
 
   fv.xScale = d3.scale.linear()
       .domain([1, d.sequence.length + 1])
-      .range([fv.padding.left, fv.width - fv.padding.right]);
+      .range([fv.margin.left, fv.width - fv.margin.right]);
 
-  fv.viewport = createNavRuler(fv, fv.header);
-  createButtons(fv, d, fv.header);
-  fv.aaViewer = createAAViewer(fv, fv.header, d.sequence);
+  fv.xZoomScale = d3.scale.linear()
+      .domain([1, d.sequence.length + 1])
+      .range([fv.zoomMargin.left, fv.width - fv.zoomMargin.right]);
+
+  var buttonsContainer     = fv.header.append('div').classed('up_pftv_leftpanel', true);
+  var scaleContainer       = fv.header.append('div').classed('up_pftv_mainpanel', true);
+  var bottomScaleContainer = fv.footer.append('div').classed('up_pftv_mainpanel', true);
+
+  fv.viewport = createNavRuler(fv, scaleContainer);
+  createButtons(fv, d, buttonsContainer);
+  fv.aaViewer = createAAViewer(fv, scaleContainer, d.sequence);
   fv.zoom = createZoom(fv);
 
-  fv.aaViewer2 = createAAViewer(fv, fv.footer, d.sequence);
+  fv.aaViewer2 = createAAViewer(fv, bottomScaleContainer, d.sequence);
   updateViewportFromChart(fv);
   updateZoomFromChart(fv);
 };

--- a/src/TrackFactory.js
+++ b/src/TrackFactory.js
@@ -19,10 +19,13 @@ var Track = function(typeFeatures, category) {
     track.category = category;
     track.id = track.type + '_track';
 
-    track.titleContainer = category.tracksContainer.append('div').style('display', 'inline-block');
+    track.titleContainer = category.tracksContainer
+      .append('div').attr('class', 'up_pftv_leftpanel')
+      .append('div').attr('class', 'up_pftv_track-header');
 
-    track.trackContainer = category.tracksContainer.append('div')
-        .attr('class', 'up_pftv_track');
+    track.trackContainer = category.tracksContainer
+      .append('div').attr('class', 'up_pftv_mainpanel')
+      .append('div').attr('class', 'up_pftv_track');
 };
 
 Track.prototype.update = function() {

--- a/src/VariantCategoryViewer.js
+++ b/src/VariantCategoryViewer.js
@@ -34,22 +34,14 @@ var VariantCategoryViewer = function(category) {
         .y(function(d) {
             return varYScale(d);
         })
-        .interpolate('linear');
+        .interpolate('step-after');
 
     this.init = function () {
         var varCatViewer = this;
+                
         varCatViewer.varChart.append("path")
             .data(varCatViewer.features)
-            .attr("class","up_pftv_block-area")
-            .attr("d",line(varCatViewer.variationCountArray))
-            .on('click', function(){
-                category.toggle();
-            })
-            .append('title').text('Number of variants per position');
-
-        varCatViewer.varChart.append("path")
-            .data(varCatViewer.features)
-            .attr("class","up_pftv_line")
+            .attr("class","up_pftv_block-area up_pftv_line")
             .attr("d",line(varCatViewer.variationCountArray))
             .on('click', function(){
                 category.toggle();

--- a/style/README.md
+++ b/style/README.md
@@ -1,0 +1,15 @@
+# WARNING
+
+The .css files in this directory are compiled from the LESS source files. Any changes here will be overwritten.
+
+If you want to make changes then edit the approrpiate LESS file:
+
+  ./less/
+
+Then rebuild:
+
+  $ gulp build
+
+The final, minified CSS files get written out to: 
+
+  ./build/css/

--- a/style/fv-theme-grey.css
+++ b/style/fv-theme-grey.css
@@ -1,0 +1,282 @@
+
+.up_pftv_navruler svg {
+  background-color: transparent;
+}
+
+.up_pftv_aaviewer .background, .up_pftv_viewport .background {
+  fill: white;
+}
+
+.up_pftv_container text.domain-label {
+  font-size: 12px !important;
+}
+
+.up_pftv_container, .up_pftv_aaviewer text {
+  font-family: Helvetica, sans-serif;
+}
+
+.up_pftv_container .up_pftv_navruler .resize {
+  font-size: 20px;
+  fill: #999;
+  fill-opacity: 1.0;
+}
+
+.up_pftv_category-container {
+  border-right: 1px solid #ddd;
+  border-top: 1px solid #ddd;
+}
+
+.up_pftv_category {
+  border-bottom-color: #ddd;
+}
+
+.up_pftv_category-name {
+  background-color: #eee;
+  text-transform: uppercase; 
+}
+
+.up_pftv_category a:hover {
+    background-color: #eeeeee;
+}
+
+.up_pftv_track-header {
+  background-color: #f3f3f3;  
+  text-align: right;
+  text-transform: uppercase; 
+}
+
+.up_pftv_track {
+  border-top: 1px solid #eee;
+}
+
+.up_pftv_disulphid {
+}
+
+
+
+/*
+d3.scale.category20()
+#1f77b4
+#aec7e8
+#ff7f0e
+#ffbb78
+#2ca02c
+#98df8a
+#d62728
+#ff9896
+#9467bd
+#c5b0d5
+#8c564b
+#c49c94
+#e377c2
+#f7b6d2
+#7f7f7f
+#c7c7c7
+#bcbd22
+#dbdb8d
+#17becf
+#9edae5
+*/
+
+/* Features */
+svg .up_pftv_chain {
+    stroke: #1f77b4;
+    fill: #1f77b4;
+}
+
+svg .up_pftv_transit {
+    stroke: #aec7e8;
+    fill: #aec7e8;
+}
+
+svg .up_pftv_init_met {
+    stroke: #ff7f0e;
+    fill: #ff7f0e;
+}
+
+svg .up_pftv_propep {
+    stroke: #ffbb78;
+    fill: #ffbb78;
+}
+
+svg .up_pftv_peptide {
+    stroke: #2ca02c;
+    fill: #2ca02c;
+}
+
+svg .up_pftv_signal {
+    stroke: #98df8a;
+    fill: #98df8a;
+}
+
+svg .up_pftv_turn {
+    stroke: #0571AF;
+    fill: #0571AF;
+}
+
+svg .up_pftv_strand {
+    stroke: #FFCC00;
+    fill: #FFCC00;
+}
+
+svg .up_pftv_helix {
+    stroke: #FF0066;
+    fill: #FF0066;
+}
+
+svg .up_pftv_crosslnk {
+    stroke: #d62728;
+    fill: #d62728;
+}
+
+svg .up_pftv_disulfid {
+    stroke: #ff9896;
+    fill: #ff9896;
+}
+
+svg .up_pftv_region {
+    stroke: #9467bd;
+    fill: #9467bd;
+}
+
+svg .up_pftv_coiled {
+    stroke: #9edae5;
+    fill: #9edae5;
+}
+
+svg .up_pftv_motif {
+    stroke: #17becf;
+    fill: #17becf;
+}
+
+svg .up_pftv_repeat {
+    stroke: #bcbd22;
+    fill: #bcbd22;
+}
+
+svg .up_pftv_ca_bind {
+    stroke: #f7b6d2;
+    fill: #f7b6d2;
+}
+
+svg .up_pftv_dna_bind {
+    stroke: #1f77b4;
+    fill: #1f77b4;
+}
+
+svg .up_pftv_domain {
+    stroke: #aec7e8;
+    fill: #aec7e8;
+}
+
+svg .up_pftv_zn_fing {
+    stroke: #ff7f0e;
+    fill: #ff7f0e;
+}
+
+svg .up_pftv_np_bind {
+    stroke: #ffbb78;
+    fill: #ffbb78;
+}
+
+svg .up_pftv_metal {
+  stroke: #f7b6d2;
+  fill: #f7b6d2;
+}
+
+svg .up_pftv_site {
+  stroke: #1f77b4;
+  fill: #1f77b4;
+}
+
+svg .up_pftv_binding {
+  stroke: #aec7e8;
+  fill: #aec7e8;
+}
+
+svg .up_pftv_act_site {
+  stroke: #17becf;
+  fill: #17becf;
+}
+
+svg .up_pftv_mod_res {
+  stroke: #0571AF;
+  fill: #0571AF;
+}
+
+svg .up_pftv_lipid {
+  stroke: #d62728;
+  fill: #d62728;
+}
+
+svg .up_pftv_carbohyd {
+  stroke: #aec7e8;
+  fill: #aec7e8;
+}
+
+svg .up_pftv_variant {
+    stroke-width: 2;
+}
+
+svg .up_pftv_compbias {
+  stroke: #0571AF;
+  fill: #0571AF;
+}
+
+svg .up_pftv_mutagen {
+  stroke: #98df8a;
+  fill: #98df8a;
+}
+
+svg .up_pftv_conflict {
+  stroke: #2ca02c;
+  fill: #2ca02c;
+}
+
+svg .up_pftv_non_cons {
+  stroke: #ffbb78;
+  fill: #ffbb78;
+}
+
+svg .up_pftv_non_ter {
+  stroke: #ff7f0e;
+  fill: #ff7f0e;
+}
+
+svg .up_pftv_unsure {
+  stroke: #f7b6d2;
+  fill: #f7b6d2;
+}
+
+svg .up_pftv_non_std {
+  stroke: #ffbb78;
+  fill: #ffbb78;
+}
+
+svg .up_pftv_topo_dom {
+  stroke: #ff7f0e;
+  fill: #ff7f0e;
+}
+
+svg .up_pftv_transmem {
+  stroke: #aec7e8;
+  fill: #aec7e8;
+}
+
+svg .up_pftv_intramem {
+  stroke: #1f77b4;
+  fill: #1f77b4;
+}
+
+svg .up_pftv_unique {
+  stroke: #f7b6d2;
+  fill: #f7b6d2;
+}
+
+svg .up_pftv_non_unique {
+  stroke: #bcbd22;
+  fill: #bcbd22;
+}
+
+
+

--- a/style/fv-theme-grey.css
+++ b/style/fv-theme-grey.css
@@ -1,282 +1,203 @@
-
-.up_pftv_navruler svg {
+/*
+specific colours
+*/
+/*
+d3.scale.category20()
+*/
+.pv-theme-grey .up_pftv_navruler svg {
   background-color: transparent;
 }
-
-.up_pftv_aaviewer .background, .up_pftv_viewport .background {
+.pv-theme-grey .up_pftv_aaviewer .background,
+.pv-theme-grey .up_pftv_viewport .background {
   fill: white;
 }
-
-.up_pftv_container text.domain-label {
+.pv-theme-grey .up_pftv_container text.domain-label {
   font-size: 12px !important;
 }
-
-.up_pftv_container, .up_pftv_aaviewer text {
+.pv-theme-grey .up_pftv_container,
+.pv-theme-grey .up_pftv_aaviewer text {
   font-family: Helvetica, sans-serif;
 }
-
-.up_pftv_container .up_pftv_navruler .resize {
+.pv-theme-grey .up_pftv_container .up_pftv_navruler .resize {
   font-size: 20px;
   fill: #999;
   fill-opacity: 1.0;
 }
-
-.up_pftv_category-container {
+.pv-theme-grey .up_pftv_category-container {
   border-right: 1px solid #ddd;
   border-top: 1px solid #ddd;
 }
-
-.up_pftv_category {
+.pv-theme-grey .up_pftv_category {
   border-bottom-color: #ddd;
 }
-
-.up_pftv_category-name {
+.pv-theme-grey .up_pftv_category-name {
   background-color: #eee;
-  text-transform: uppercase; 
+  text-transform: uppercase;
 }
-
-.up_pftv_category a:hover {
-    background-color: #eeeeee;
+.pv-theme-grey .up_pftv_category a:hover {
+  background-color: #eeeeee;
 }
-
-.up_pftv_track-header {
-  background-color: #f3f3f3;  
+.pv-theme-grey .up_pftv_track-header {
+  background-color: #f3f3f3;
   text-align: right;
-  text-transform: uppercase; 
+  text-transform: uppercase;
 }
-
-.up_pftv_track {
+.pv-theme-grey .up_pftv_track {
   border-top: 1px solid #eee;
 }
-
-.up_pftv_disulphid {
-}
-
-
-
-/*
-d3.scale.category20()
-#1f77b4
-#aec7e8
-#ff7f0e
-#ffbb78
-#2ca02c
-#98df8a
-#d62728
-#ff9896
-#9467bd
-#c5b0d5
-#8c564b
-#c49c94
-#e377c2
-#f7b6d2
-#7f7f7f
-#c7c7c7
-#bcbd22
-#dbdb8d
-#17becf
-#9edae5
-*/
-
-/* Features */
-svg .up_pftv_chain {
-    stroke: #1f77b4;
-    fill: #1f77b4;
-}
-
-svg .up_pftv_transit {
-    stroke: #aec7e8;
-    fill: #aec7e8;
-}
-
-svg .up_pftv_init_met {
-    stroke: #ff7f0e;
-    fill: #ff7f0e;
-}
-
-svg .up_pftv_propep {
-    stroke: #ffbb78;
-    fill: #ffbb78;
-}
-
-svg .up_pftv_peptide {
-    stroke: #2ca02c;
-    fill: #2ca02c;
-}
-
-svg .up_pftv_signal {
-    stroke: #98df8a;
-    fill: #98df8a;
-}
-
-svg .up_pftv_turn {
-    stroke: #0571AF;
-    fill: #0571AF;
-}
-
-svg .up_pftv_strand {
-    stroke: #FFCC00;
-    fill: #FFCC00;
-}
-
-svg .up_pftv_helix {
-    stroke: #FF0066;
-    fill: #FF0066;
-}
-
-svg .up_pftv_crosslnk {
-    stroke: #d62728;
-    fill: #d62728;
-}
-
-svg .up_pftv_disulfid {
-    stroke: #ff9896;
-    fill: #ff9896;
-}
-
-svg .up_pftv_region {
-    stroke: #9467bd;
-    fill: #9467bd;
-}
-
-svg .up_pftv_coiled {
-    stroke: #9edae5;
-    fill: #9edae5;
-}
-
-svg .up_pftv_motif {
-    stroke: #17becf;
-    fill: #17becf;
-}
-
-svg .up_pftv_repeat {
-    stroke: #bcbd22;
-    fill: #bcbd22;
-}
-
-svg .up_pftv_ca_bind {
-    stroke: #f7b6d2;
-    fill: #f7b6d2;
-}
-
-svg .up_pftv_dna_bind {
-    stroke: #1f77b4;
-    fill: #1f77b4;
-}
-
-svg .up_pftv_domain {
-    stroke: #aec7e8;
-    fill: #aec7e8;
-}
-
-svg .up_pftv_zn_fing {
-    stroke: #ff7f0e;
-    fill: #ff7f0e;
-}
-
-svg .up_pftv_np_bind {
-    stroke: #ffbb78;
-    fill: #ffbb78;
-}
-
-svg .up_pftv_metal {
-  stroke: #f7b6d2;
-  fill: #f7b6d2;
-}
-
-svg .up_pftv_site {
+.pv-theme-grey svg .up_pftv_chain {
   stroke: #1f77b4;
   fill: #1f77b4;
 }
-
-svg .up_pftv_binding {
+.pv-theme-grey svg .up_pftv_transit {
   stroke: #aec7e8;
   fill: #aec7e8;
 }
-
-svg .up_pftv_act_site {
-  stroke: #17becf;
-  fill: #17becf;
+.pv-theme-grey svg .up_pftv_init_met {
+  stroke: #ff7f0e;
+  fill: #ff7f0e;
 }
-
-svg .up_pftv_mod_res {
-  stroke: #0571AF;
-  fill: #0571AF;
+.pv-theme-grey svg .up_pftv_propep {
+  stroke: #ffbb78;
+  fill: #ffbb78;
 }
-
-svg .up_pftv_lipid {
-  stroke: #d62728;
-  fill: #d62728;
-}
-
-svg .up_pftv_carbohyd {
-  stroke: #aec7e8;
-  fill: #aec7e8;
-}
-
-svg .up_pftv_variant {
-    stroke-width: 2;
-}
-
-svg .up_pftv_compbias {
-  stroke: #0571AF;
-  fill: #0571AF;
-}
-
-svg .up_pftv_mutagen {
-  stroke: #98df8a;
-  fill: #98df8a;
-}
-
-svg .up_pftv_conflict {
+.pv-theme-grey svg .up_pftv_peptide {
   stroke: #2ca02c;
   fill: #2ca02c;
 }
-
-svg .up_pftv_non_cons {
-  stroke: #ffbb78;
-  fill: #ffbb78;
+.pv-theme-grey svg .up_pftv_signal {
+  stroke: #98df8a;
+  fill: #98df8a;
 }
-
-svg .up_pftv_non_ter {
-  stroke: #ff7f0e;
-  fill: #ff7f0e;
+.pv-theme-grey svg .up_pftv_crosslnk {
+  stroke: #c5b0d5;
+  fill: #c5b0d5;
 }
-
-svg .up_pftv_unsure {
+.pv-theme-grey svg .up_pftv_disulfid {
+  stroke: #8c564b;
+  fill: #8c564b;
+}
+.pv-theme-grey svg .up_pftv_region {
+  stroke: #c49c94;
+  fill: #c49c94;
+}
+.pv-theme-grey svg .up_pftv_coiled {
+  stroke: #e377c2;
+  fill: #e377c2;
+}
+.pv-theme-grey svg .up_pftv_motif {
   stroke: #f7b6d2;
   fill: #f7b6d2;
 }
-
-svg .up_pftv_non_std {
-  stroke: #ffbb78;
-  fill: #ffbb78;
+.pv-theme-grey svg .up_pftv_repeat {
+  stroke: #7f7f7f;
+  fill: #7f7f7f;
 }
-
-svg .up_pftv_topo_dom {
-  stroke: #ff7f0e;
-  fill: #ff7f0e;
+.pv-theme-grey svg .up_pftv_ca_bind {
+  stroke: #c7c7c7;
+  fill: #c7c7c7;
 }
-
-svg .up_pftv_transmem {
-  stroke: #aec7e8;
-  fill: #aec7e8;
-}
-
-svg .up_pftv_intramem {
-  stroke: #1f77b4;
-  fill: #1f77b4;
-}
-
-svg .up_pftv_unique {
-  stroke: #f7b6d2;
-  fill: #f7b6d2;
-}
-
-svg .up_pftv_non_unique {
+.pv-theme-grey svg .up_pftv_dna_bind {
   stroke: #bcbd22;
   fill: #bcbd22;
 }
-
-
-
+.pv-theme-grey svg .up_pftv_domain {
+  stroke: #dbdb8d;
+  fill: #dbdb8d;
+}
+.pv-theme-grey svg .up_pftv_zn_fing {
+  stroke: #17becf;
+  fill: #17becf;
+}
+.pv-theme-grey svg .up_pftv_np_bind {
+  stroke: #9edae5;
+  fill: #9edae5;
+}
+.pv-theme-grey svg .up_pftv_metal {
+  stroke: #1f77b4;
+  fill: #1f77b4;
+}
+.pv-theme-grey svg .up_pftv_binding {
+  stroke: #aec7e8;
+  fill: #aec7e8;
+}
+.pv-theme-grey svg .up_pftv_act_site {
+  stroke: #ff7f0e;
+  fill: #ff7f0e;
+}
+.pv-theme-grey svg .up_pftv_mod_res {
+  stroke: #ffbb78;
+  fill: #ffbb78;
+}
+.pv-theme-grey svg .up_pftv_lipid {
+  stroke: #2ca02c;
+  fill: #2ca02c;
+}
+.pv-theme-grey svg .up_pftv_carbohyd {
+  stroke: #98df8a;
+  fill: #98df8a;
+}
+.pv-theme-grey svg .up_pftv_variant {
+  stroke: #d62728;
+  fill: #d62728;
+}
+.pv-theme-grey svg .up_pftv_compbias {
+  stroke: #ff9896;
+  fill: #ff9896;
+}
+.pv-theme-grey svg .up_pftv_mutagen {
+  stroke: #9467bd;
+  fill: #9467bd;
+}
+.pv-theme-grey svg .up_pftv_conflict {
+  stroke: #c5b0d5;
+  fill: #c5b0d5;
+}
+.pv-theme-grey svg .up_pftv_non_cons {
+  stroke: #8c564b;
+  fill: #8c564b;
+}
+.pv-theme-grey svg .up_pftv_non_ter {
+  stroke: #c49c94;
+  fill: #c49c94;
+}
+.pv-theme-grey svg .up_pftv_unsure {
+  stroke: #e377c2;
+  fill: #e377c2;
+}
+.pv-theme-grey svg .up_pftv_non_std {
+  stroke: #f7b6d2;
+  fill: #f7b6d2;
+}
+.pv-theme-grey svg .up_pftv_topo_dom {
+  stroke: #7f7f7f;
+  fill: #7f7f7f;
+}
+.pv-theme-grey svg .up_pftv_transmem {
+  stroke: #c7c7c7;
+  fill: #c7c7c7;
+}
+.pv-theme-grey svg .up_pftv_intramem {
+  stroke: #bcbd22;
+  fill: #bcbd22;
+}
+.pv-theme-grey svg .up_pftv_unique {
+  stroke: #dbdb8d;
+  fill: #dbdb8d;
+}
+.pv-theme-grey svg .up_pftv_non_unique {
+  stroke: #17becf;
+  fill: #17becf;
+}
+.pv-theme-grey svg .up_pftv_turn {
+  stroke: #0571AF;
+  fill: #0571AF;
+}
+.pv-theme-grey svg .up_pftv_strand {
+  stroke: #FFCC00;
+  fill: #FFCC00;
+}
+.pv-theme-grey svg .up_pftv_helix {
+  stroke: #FF0066;
+  fill: #FF0066;
+}

--- a/style/fv-theme-grey.less
+++ b/style/fv-theme-grey.less
@@ -1,30 +1,33 @@
 /*
+specific colours
+*/
+@c_helix:  #FF0066;
+@c_strand: #FFCC00;
+@c_turn:   #0571AF;
+
+/*
 d3.scale.category20()
 */
-@c_helix:  #FF0066
-@c_strand: #FFCC00
-@c_turn:   #0571AF
-
-@c1: #1f77b4
-@c2: #aec7e8
-@c3: #ff7f0e
-@c4: #ffbb78
-@c5: #2ca02c
-@c6: #98df8a
-@c7: #d62728
-@c8: #ff9896
-@c9: #9467bd
-@c10: #c5b0d5
-@c11: #8c564b
-@c12: #c49c94
-@c13: #e377c2
-@c14: #f7b6d2
-@c15: #7f7f7f
-@c16: #c7c7c7
-@c17: #bcbd22
-@c18: #dbdb8d
-@c19: #17becf
-@c20: #9edae5
+@c1: #1f77b4;
+@c2: #aec7e8;
+@c3: #ff7f0e;
+@c4: #ffbb78;
+@c5: #2ca02c;
+@c6: #98df8a;
+@c7: #d62728;
+@c8: #ff9896;
+@c9: #9467bd;
+@c10: #c5b0d5;
+@c11: #8c564b;
+@c12: #c49c94;
+@c13: #e377c2;
+@c14: #f7b6d2;
+@c15: #7f7f7f;
+@c16: #c7c7c7;
+@c17: #bcbd22;
+@c18: #dbdb8d;
+@c19: #17becf;
+@c20: #9edae5;
 
 .pv-theme-grey {
   .up_pftv_navruler svg {
@@ -106,101 +109,20 @@ d3.scale.category20()
   svg .up_pftv_variant           { stroke: @c7;  fill: @c7; }
   svg .up_pftv_compbias          { stroke: @c8;  fill: @c8; }
   svg .up_pftv_mutagen           { stroke: @c9;  fill: @c9; }
+  svg .up_pftv_conflict          { stroke: @c10; fill: @c10; }
+  svg .up_pftv_non_cons          { stroke: @c11; fill: @c11; }
+  svg .up_pftv_non_ter           { stroke: @c12; fill: @c12; }
+  svg .up_pftv_unsure            { stroke: @c13; fill: @c13; }
+  svg .up_pftv_non_std           { stroke: @c14; fill: @c14; }
+  svg .up_pftv_topo_dom          { stroke: @c15; fill: @c15; }
+  svg .up_pftv_transmem          { stroke: @c16; fill: @c16; }  
+  svg .up_pftv_intramem          { stroke: @c17; fill: @c17; }
+  svg .up_pftv_unique            { stroke: @c18; fill: @c18; }
+  svg .up_pftv_non_unique        { stroke: @c19; fill: @c19; }
 
   svg .up_pftv_turn              { stroke: @c_turn;   fill: @c_turn; }
   svg .up_pftv_strand            { stroke: @c_strand; fill: @c_strand; }
   svg .up_pftv_helix             { stroke: @c_helix;  fill: @c_helix;  }
-
 }
-
-svg .up_pftv_binding {
-  stroke: #aec7e8;
-  fill: #aec7e8;
-}
-
-svg .up_pftv_act_site {
-  stroke: #17becf;
-  fill: #17becf;
-}
-
-svg .up_pftv_mod_res {
-  stroke: #0571AF;
-  fill: #0571AF;
-}
-
-svg .up_pftv_lipid {
-  stroke: #d62728;
-  fill: #d62728;
-}
-
-svg .up_pftv_carbohyd {
-  stroke: #aec7e8;
-  fill: #aec7e8;
-}
-
-svg .up_pftv_variant {
-    stroke-width: 2;
-}
-
-svg .up_pftv_compbias {
-  stroke: #0571AF;
-  fill: #0571AF;
-}
-
-svg .up_pftv_mutagen {
-  stroke: #98df8a;
-  fill: #98df8a;
-}
-
-svg .up_pftv_conflict {
-  stroke: #2ca02c;
-  fill: #2ca02c;
-}
-
-svg .up_pftv_non_cons {
-  stroke: #ffbb78;
-  fill: #ffbb78;
-}
-
-svg .up_pftv_non_ter {
-  stroke: #ff7f0e;
-  fill: #ff7f0e;
-}
-
-svg .up_pftv_unsure {
-  stroke: #f7b6d2;
-  fill: #f7b6d2;
-}
-
-svg .up_pftv_non_std {
-  stroke: #ffbb78;
-  fill: #ffbb78;
-}
-
-svg .up_pftv_topo_dom {
-  stroke: #ff7f0e;
-  fill: #ff7f0e;
-}
-
-svg .up_pftv_transmem {
-  stroke: #aec7e8;
-  fill: #aec7e8;
-}
-
-svg .up_pftv_intramem {
-  stroke: #1f77b4;
-  fill: #1f77b4;
-}
-
-svg .up_pftv_unique {
-  stroke: #f7b6d2;
-  fill: #f7b6d2;
-}
-
-svg .up_pftv_non_unique {
-  stroke: #bcbd22;
-  fill: #bcbd22;
-}
-
 
 

--- a/style/fv-theme-grey.less
+++ b/style/fv-theme-grey.less
@@ -1,0 +1,206 @@
+/*
+d3.scale.category20()
+*/
+@c_helix:  #FF0066
+@c_strand: #FFCC00
+@c_turn:   #0571AF
+
+@c1: #1f77b4
+@c2: #aec7e8
+@c3: #ff7f0e
+@c4: #ffbb78
+@c5: #2ca02c
+@c6: #98df8a
+@c7: #d62728
+@c8: #ff9896
+@c9: #9467bd
+@c10: #c5b0d5
+@c11: #8c564b
+@c12: #c49c94
+@c13: #e377c2
+@c14: #f7b6d2
+@c15: #7f7f7f
+@c16: #c7c7c7
+@c17: #bcbd22
+@c18: #dbdb8d
+@c19: #17becf
+@c20: #9edae5
+
+.pv-theme-grey {
+  .up_pftv_navruler svg {
+    background-color: transparent;
+  }
+
+  .up_pftv_aaviewer .background, .up_pftv_viewport .background {
+    fill: white;
+  }
+
+  .up_pftv_container text.domain-label {
+    font-size: 12px !important;
+  }
+
+  .up_pftv_container, .up_pftv_aaviewer text {
+    font-family: Helvetica, sans-serif;
+  }
+
+  .up_pftv_container .up_pftv_navruler .resize {
+    font-size: 20px;
+    fill: #999;
+    fill-opacity: 1.0;
+  }
+
+  .up_pftv_category-container {
+    border-right: 1px solid #ddd;
+    border-top: 1px solid #ddd;
+  }
+
+  .up_pftv_category {
+    border-bottom-color: #ddd;
+  }
+
+  .up_pftv_category-name {
+    background-color: #eee;
+    text-transform: uppercase; 
+  }
+
+  .up_pftv_category a:hover {
+      background-color: #eeeeee;
+  }
+
+  .up_pftv_track-header {
+    background-color: #f3f3f3;  
+    text-align: right;
+    text-transform: uppercase; 
+  }
+
+  .up_pftv_track {
+    border-top: 1px solid #eee;
+  }
+
+  .up_pftv_disulphid {
+  }
+
+  svg .up_pftv_chain             { stroke: @c1;  fill: @c1;  }
+  svg .up_pftv_transit           { stroke: @c2;  fill: @c2;  }
+  svg .up_pftv_init_met          { stroke: @c3;  fill: @c3;  }
+  svg .up_pftv_propep            { stroke: @c4;  fill: @c4;  }
+  svg .up_pftv_peptide           { stroke: @c5;  fill: @c5;  }
+  svg .up_pftv_signal            { stroke: @c6;  fill: @c6;  }
+  svg .up_pftv_crosslnk          { stroke: @c10; fill: @c10; }
+  svg .up_pftv_disulfid          { stroke: @c11; fill: @c11; }
+  svg .up_pftv_region            { stroke: @c12; fill: @c12; }
+  svg .up_pftv_coiled            { stroke: @c13; fill: @c13; }
+  svg .up_pftv_motif             { stroke: @c14; fill: @c14; }
+  svg .up_pftv_repeat            { stroke: @c15; fill: @c15; }
+  svg .up_pftv_ca_bind           { stroke: @c16; fill: @c16; }
+  svg .up_pftv_dna_bind          { stroke: @c17; fill: @c17; }
+  svg .up_pftv_domain            { stroke: @c18; fill: @c18; }
+  svg .up_pftv_zn_fing           { stroke: @c19; fill: @c19; }
+  svg .up_pftv_np_bind           { stroke: @c20; fill: @c20; }
+  svg .up_pftv_metal             { stroke: @c1;  fill: @c1; }
+  svg .up_pftv_binding           { stroke: @c2;  fill: @c2; }
+  svg .up_pftv_act_site          { stroke: @c3;  fill: @c3; }
+  svg .up_pftv_mod_res           { stroke: @c4;  fill: @c4; }
+  svg .up_pftv_lipid             { stroke: @c5;  fill: @c5; }
+  svg .up_pftv_carbohyd          { stroke: @c6;  fill: @c6; }
+  svg .up_pftv_variant           { stroke: @c7;  fill: @c7; }
+  svg .up_pftv_compbias          { stroke: @c8;  fill: @c8; }
+  svg .up_pftv_mutagen           { stroke: @c9;  fill: @c9; }
+
+  svg .up_pftv_turn              { stroke: @c_turn;   fill: @c_turn; }
+  svg .up_pftv_strand            { stroke: @c_strand; fill: @c_strand; }
+  svg .up_pftv_helix             { stroke: @c_helix;  fill: @c_helix;  }
+
+}
+
+svg .up_pftv_binding {
+  stroke: #aec7e8;
+  fill: #aec7e8;
+}
+
+svg .up_pftv_act_site {
+  stroke: #17becf;
+  fill: #17becf;
+}
+
+svg .up_pftv_mod_res {
+  stroke: #0571AF;
+  fill: #0571AF;
+}
+
+svg .up_pftv_lipid {
+  stroke: #d62728;
+  fill: #d62728;
+}
+
+svg .up_pftv_carbohyd {
+  stroke: #aec7e8;
+  fill: #aec7e8;
+}
+
+svg .up_pftv_variant {
+    stroke-width: 2;
+}
+
+svg .up_pftv_compbias {
+  stroke: #0571AF;
+  fill: #0571AF;
+}
+
+svg .up_pftv_mutagen {
+  stroke: #98df8a;
+  fill: #98df8a;
+}
+
+svg .up_pftv_conflict {
+  stroke: #2ca02c;
+  fill: #2ca02c;
+}
+
+svg .up_pftv_non_cons {
+  stroke: #ffbb78;
+  fill: #ffbb78;
+}
+
+svg .up_pftv_non_ter {
+  stroke: #ff7f0e;
+  fill: #ff7f0e;
+}
+
+svg .up_pftv_unsure {
+  stroke: #f7b6d2;
+  fill: #f7b6d2;
+}
+
+svg .up_pftv_non_std {
+  stroke: #ffbb78;
+  fill: #ffbb78;
+}
+
+svg .up_pftv_topo_dom {
+  stroke: #ff7f0e;
+  fill: #ff7f0e;
+}
+
+svg .up_pftv_transmem {
+  stroke: #aec7e8;
+  fill: #aec7e8;
+}
+
+svg .up_pftv_intramem {
+  stroke: #1f77b4;
+  fill: #1f77b4;
+}
+
+svg .up_pftv_unique {
+  stroke: #f7b6d2;
+  fill: #f7b6d2;
+}
+
+svg .up_pftv_non_unique {
+  stroke: #bcbd22;
+  fill: #bcbd22;
+}
+
+
+


### PR DESCRIPTION
This was originally meant to just be adding a CSS theme, however it ended up being a bit more extensive. I've separated the changes out into individual commits as best as I could.

Overview:

  * changes to the default look and feel of the zoom scale
  * use left/main panel to help alignment of columns
  * allow themes to be applied to default look and feel 
  * integrated LESS to reduce duplication when generating CSS (for main.css and themes)
  * minor fixes to CSS

Example screenshot (from the sniper example):

![prot-vista](https://cloud.githubusercontent.com/assets/152954/23275093/10140b46-f9fd-11e6-8f68-bf33c9141b66.png)
