### PR TITLE
Responsive resizing 

### DIFF
--- a/example.html
+++ b/example.html
@@ -2,10 +2,45 @@
 <script src="build/ProtVista.js"></script>
 <link href="build/css/main.css" rel="stylesheet"/>
 
-<div id=yourDiv></div>
+<style>
+    h2 {
+        text-align: center;
+        padding-top: 10px;
+    }
+</style>
+
+<h2>Fixed width</h2>
+<div style="margin: 10px">
+    For fixed width, the PV containing div needs to have a set width.
+</div>
+<div id="yourDivFixed" style="width: 800px"></div>
+
+<h2>Dynamic size</h2>
+<div style="margin: 10px">
+    Without set width, a DIV elemebt takes 100% of width of the parent element (window in this case).
+    Because ProtVista plugin is listening to its embedded iframe window resize event, it scales accordingly.
+</div>
+<div id="yourDivDynamic"></div>
+
+<h2>Dynamic size with minimal width</h2>
+<div style="margin: 10px">
+    It is possible to set a minimal width which the ProtVista plugin can take (600px here).
+</div>
+<div id="yourDivDynamicMin"></div>
+
+
 <script>
 // you can
-var yourDiv = document.getElementById("yourDiv");
 var ProtVista = require('ProtVista');
-new ProtVista({el: yourDiv, uniprotacc : 'P05067'});
+
+var yourDivFixed = document.getElementById("yourDivFixed");
+new ProtVista({el: yourDivFixed, uniprotacc : 'P05067'});
+
+var yourDivDynamic = document.getElementById("yourDivDynamic");
+new ProtVista({el: yourDivDynamic, uniprotacc : 'P05067'});
+
+var yourDivDynamicMin = document.getElementById("yourDivDynamicMin");
+new ProtVista({el: yourDivDynamicMin, uniprotacc : 'P05067', minWidth : 600});
+
+
 </script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -162,7 +162,9 @@ gulp.task('build-browser-min',['copy-resources'], function() {
     return b.bundle()
         .pipe(source(outputFile + ".min.js"))
         .pipe(chmod(644))
-        .pipe(streamify(uglify()))
+        .pipe(streamify(uglify().on('error', function(e){
+            console.log(e);
+        })))
         .pipe(gulp.dest(buildDir));
 });
 

--- a/src/CategoryFactory.js
+++ b/src/CategoryFactory.js
@@ -25,7 +25,13 @@ var Category = function(name, data, catInfo, fv, container) {
 
     category.categoryContainer = container.append('div')
         .attr('class', 'up_pftv_category');
-    category.header = category.categoryContainer.append('a')
+    let headerRow = category.categoryContainer.append('div')
+        .style('display', 'table-caption')
+        .append('div')
+            .style('display', 'table')
+            .style('width', '100%')
+
+    category.header = headerRow.append('a')
         .attr('class', 'up_pftv_category-name up_pftv_arrow-right')
         .attr('title', category.name)
         .text(catInfo.label)
@@ -34,12 +40,14 @@ var Category = function(name, data, catInfo, fv, container) {
             category.propagateSelection();
         });
 
-    category.viewerContainer = category.categoryContainer.append('div')
+    category.viewerContainer = headerRow.append('div')
         .attr('class', 'up_pftv_category-viewer');
 
     category.tracksContainer = category.categoryContainer.append('div')
-        .attr('class', 'up_pftv_category-tracks')
-        .style('display','none');
+        .style('display','table-row')
+        .append('div')
+            .attr('class', 'up_pftv_category-tracks')
+            .style('display','none');
 };
 
 Category.prototype.reset = function() {

--- a/src/CategoryFactory.js
+++ b/src/CategoryFactory.js
@@ -25,7 +25,7 @@ var Category = function(name, data, catInfo, fv, container) {
 
     category.categoryContainer = container.append('div')
         .attr('class', 'up_pftv_category');
-    let headerRow = category.categoryContainer.append('div')
+    var headerRow = category.categoryContainer.append('div')
         .style('display', 'table-caption')
         .append('div')
             .style('display', 'table')

--- a/src/CategoryFactory.js
+++ b/src/CategoryFactory.js
@@ -29,7 +29,7 @@ var Category = function(name, data, catInfo, fv, container) {
         .style('display', 'table-caption')
         .append('div')
             .style('display', 'table')
-            .style('width', '100%')
+            .style('width', '100%');
 
     category.header = headerRow.append('a')
         .attr('class', 'up_pftv_category-name up_pftv_arrow-right')

--- a/src/DataLoader.js
+++ b/src/DataLoader.js
@@ -50,7 +50,9 @@ var setVariantData = function (source, d) {
 var DataLoader = function() {
     return {
         get: function(url) {
-          return $.getJSON(url);
+            //IE does not support data URI, therefore such data sources need to be parsed directly
+            return url.indexOf("data:") == 0 ? $.Deferred().resolve(JSON.parse(decodeURI(url).replace(/[^,]*,/, ''))) : $.getJSON(url);
+          // return $.getJSON(url);
         },
         groupFeaturesByCategory: function(features, sequence, source, includeVariants) {
             features = groupEvidencesByCode(features);

--- a/src/DataLoader.js
+++ b/src/DataLoader.js
@@ -50,9 +50,7 @@ var setVariantData = function(source, d) {
 var DataLoader = function() {
     return {
         get: function(url) {
-            //IE does not support data URI, therefore such data sources need to be parsed directly
-            return url.indexOf("data:") == 0 ? $.Deferred().resolve(JSON.parse(decodeURI(url).replace(/[^,]*,/, ''))) : $.getJSON(url);
-          // return $.getJSON(url);
+          return $.getJSON(url);
         },
         groupFeaturesByCategory: function(features, sequence, source, includeVariants) {
             features = groupEvidencesByCode(features);

--- a/src/FeaturesViewer.js
+++ b/src/FeaturesViewer.js
@@ -422,9 +422,7 @@ var loadSources = function(opts, dataSources, loaders, delegates, fv) {
     fv.initLayout(opts);
     _.each(dataSources, function(source, index) {
         if (!_.contains(opts.exclusions, source.category)) {
-            var url = source.url;
-            if (url.indexOf("data:") != 0)
-                url += opts.uniprotacc;
+            var url = source.url + opts.uniprotacc;
             url = source.useExtension === true ? url + '.json' : url;
             var dataLoader = DataLoader.get(url);
             loaders.push(dataLoader);

--- a/src/FeaturesViewer.js
+++ b/src/FeaturesViewer.js
@@ -479,12 +479,12 @@ var getFvWidth = function(fv){
     var width = jQuery(fv.parentElement).width() - divCategoryName.outerWidth(false);
     divCategoryName.remove();
     return width;
-}
+};
 
 var getFvXScaleRange =  function(fv, padding) {
     return padding ? [fv.padding.left, fv.width - fv.padding.right] : [0, fv.width];
 
-}
+};
 
 var FeaturesViewer = function(opts) {
 
@@ -756,6 +756,6 @@ FeaturesViewer.prototype.resize = function() {
     update(fv);
     updateZoomFromChart(fv);
     updateViewportFromChart(fv);
-}
+};
 
 module.exports = FeaturesViewer;

--- a/src/FeaturesViewer.js
+++ b/src/FeaturesViewer.js
@@ -467,16 +467,25 @@ var loadSources = function(opts, dataSources, loaders, delegates, fv) {
     });
 };
 
+var getFvWidth = function(fv){
+    var divCategoryName = jQuery('<div class="up_pftv_category-name"></div>').appendTo(jQuery("body"));
+    var width = jQuery(fv.parentElement).width() - divCategoryName.outerWidth(true);
+    divCategoryName.remove();
+    return width;
+}
+
+var getFvXScaleRange =  function(fv) {
+    return [fv.padding.left, fv.width - fv.padding.right];
+}
 
 var FeaturesViewer = function(opts) {
+
     var fv = this;
     fv.dispatcher = d3.dispatch("featureSelected", "featureDeselected", "ready", "noDataAvailable", "noDataRetrieved",
         "notFound", "notConfigRetrieved", "regionHighlighted");
 
-    var divCategoryName = jQuery('<div class="up_pftv_category-name"></div>').appendTo(jQuery("body"));
-    fv.width = jQuery(opts.el).width() - divCategoryName.outerWidth(true);
-    divCategoryName.remove();
-
+    fv.parentElement = opts.el;
+    fv.width = getFvWidth(fv);
     fv.maxZoomSize = 30;
     fv.selectedFeature = undefined;
     fv.selectedFeatureElement = undefined;
@@ -488,6 +497,16 @@ var FeaturesViewer = function(opts) {
     fv.uniprotacc = opts.uniprotacc;
     fv.overwritePredictions = opts.overwritePredictions;
     fv.defaultSource = opts.defaultSources !== undefined ? opts.defaultSources : true;
+
+    jQuery(window).on("resize", function(){
+        fv.width = getFvWidth(fv);
+
+        fv.xScale.range(getFvXScaleRange(fv));
+
+        fv.categories.forEach(function (cat){
+            cat.update();
+        });
+    });
 
     fv.load = function() {
         initSources(opts);
@@ -666,7 +685,7 @@ FeaturesViewer.prototype.loadZoom = function(d) {
 
   fv.xScale = d3.scale.linear()
       .domain([1, d.sequence.length + 1])
-      .range([fv.padding.left, fv.width - fv.padding.right]);
+      .range(getFvXScaleRange(fv));
 
   fv.viewport = createNavRuler(fv, fv.header);
   fv.header = fv.header.append('div')

--- a/src/FeaturesViewer.js
+++ b/src/FeaturesViewer.js
@@ -415,7 +415,9 @@ var loadSources = function(opts, dataSources, loaders, delegates, fv) {
     fv.initLayout(opts);
     _.each(dataSources, function(source, index) {
         if (!_.contains(opts.exclusions, source.category)) {
-            var url = source.url + opts.uniprotacc;
+            var url = source.url;
+            if (url.indexOf("data:") != 0)
+                url += opts.uniprotacc;
             url = source.useExtension === true ? url + '.json' : url;
             var dataLoader = DataLoader.get(url);
             loaders.push(dataLoader);

--- a/src/FeaturesViewer.js
+++ b/src/FeaturesViewer.js
@@ -142,8 +142,8 @@ var createNavRuler = function(fv, container) {
         .append('svg')
         .attr('id','up_pftv_svg-navruler')
         .attr('width', "100%")
-        .attr('height', (navWithTrapezoid))
-        .attr('viewBox', function(){return "0,0," + fv.width + "," + navWithTrapezoid;});
+        .attr('height', (navWithTrapezoid));
+        // .attr('viewBox', function(){return "0,0," + fv.width + "," + navWithTrapezoid;});
 
     var navXAxis = d3.svg.axis()
         .scale(fv.xScale)
@@ -283,8 +283,8 @@ var createAAViewer = function(fv, container, sequence) {
         .attr('class','up_pftv_aaviewer')
         .append('svg')
         .attr('width', "100%")
-        .attr('height',aaViewHeight)
-        .attr('viewBox', function(){return "0,0," + aaViewWidth + "," + aaViewHeight;});
+        .attr('height',aaViewHeight);
+        // .attr('viewBox', function(){return "0,0," + aaViewWidth + "," + aaViewHeight;});
 
     //amino acids selector
     var aaSelectorPlot = function(){
@@ -467,12 +467,16 @@ var loadSources = function(opts, dataSources, loaders, delegates, fv) {
     });
 };
 
+
 var FeaturesViewer = function(opts) {
     var fv = this;
     fv.dispatcher = d3.dispatch("featureSelected", "featureDeselected", "ready", "noDataAvailable", "noDataRetrieved",
         "notFound", "notConfigRetrieved", "regionHighlighted");
 
-    fv.width = jQuery(opts.el).width()-1;
+    var divCategoryName = jQuery('<div class="up_pftv_category-name"></div>').appendTo(jQuery("body"));
+    fv.width = jQuery(opts.el).width() - divCategoryName.outerWidth(true);
+    divCategoryName.remove();
+
     fv.maxZoomSize = 30;
     fv.selectedFeature = undefined;
     fv.selectedFeatureElement = undefined;

--- a/src/FeaturesViewer.js
+++ b/src/FeaturesViewer.js
@@ -141,8 +141,9 @@ var createNavRuler = function(fv, container) {
         .attr('class', 'up_pftv_navruler')
         .append('svg')
         .attr('id','up_pftv_svg-navruler')
-        .attr('width', fv.width)
-        .attr('height', (navWithTrapezoid));
+        .attr('width', "100%")
+        .attr('height', (navWithTrapezoid))
+        .attr('viewBox', function(){return "0,0," + fv.width + "," + navWithTrapezoid;});
 
     var navXAxis = d3.svg.axis()
         .scale(fv.xScale)
@@ -281,8 +282,9 @@ var createAAViewer = function(fv, container, sequence) {
         .append('div')
         .attr('class','up_pftv_aaviewer')
         .append('svg')
-        .attr('width', aaViewWidth)
-        .attr('height',aaViewHeight);
+        .attr('width', "100%")
+        .attr('height',aaViewHeight)
+        .attr('viewBox', function(){return "0,0," + aaViewWidth + "," + aaViewHeight;});
 
     //amino acids selector
     var aaSelectorPlot = function(){
@@ -468,7 +470,7 @@ var FeaturesViewer = function(opts) {
     fv.dispatcher = d3.dispatch("featureSelected", "featureDeselected", "ready", "noDataAvailable", "noDataRetrieved",
         "notFound", "notConfigRetrieved", "regionHighlighted");
 
-    fv.width = 760;
+    fv.width = jQuery(opts.el).width()-1;
     fv.maxZoomSize = 30;
     fv.selectedFeature = undefined;
     fv.selectedFeatureElement = undefined;
@@ -661,6 +663,11 @@ FeaturesViewer.prototype.loadZoom = function(d) {
       .range([fv.padding.left, fv.width - fv.padding.right]);
 
   fv.viewport = createNavRuler(fv, fv.header);
+  fv.header = fv.header.append('div')
+      .style('display', 'table')
+      .style('width', '100%')
+      .append('div')
+        .style('display', 'table-row');
   createButtons(fv, d, fv.header);
   fv.aaViewer = createAAViewer(fv, fv.header, d.sequence);
   fv.zoom = createZoom(fv);

--- a/src/TrackFactory.js
+++ b/src/TrackFactory.js
@@ -19,10 +19,18 @@ var Track = function(typeFeatures, category) {
     track.category = category;
     track.id = track.type + '_track';
 
-    track.titleContainer = category.tracksContainer.append('div').style('display', 'inline-block');
+    var tab = category.tracksContainer.append('div').style("display", "table").style("width", "100%");
+    var row = tab.append('div').style("display", "table-row");
 
-    track.trackContainer = category.tracksContainer.append('div')
+    track.titleContainer = row.append('div').style('display', 'table-cell');
+
+    track.trackContainer = row.append('div')
         .attr('class', 'up_pftv_track');
+
+    // category.tracksContainer.append('div').attr("class", "up_pftv-clear");
+
+
+
 };
 
 Track.prototype.update = function() {

--- a/src/VariantViewer.js
+++ b/src/VariantViewer.js
@@ -154,7 +154,7 @@ var drawVariants = function(variantViewer, bars, frequency, fv, container, catTi
 
 var updateChartArea = function(variantViewer){
     variantViewer.svg.select('#plotAreaClip rect')
-        .attr("width", function(){return getClipPathWidth(variantViewer)});
+        .attr("width", function(){return getClipPathWidth(variantViewer);});
 
     variantViewer.svg.selectAll('.variation-y.axis.left line')
         .attr('x2', getAxisLength(variantViewer));
@@ -162,15 +162,15 @@ var updateChartArea = function(variantViewer){
     variantViewer.svg.selectAll('.variation-y.axis.right')
         .attr('transform','translate(' + getAxisLength(variantViewer) + ', 0)');
 
-}
+};
 
 var getClipPathWidth = function(variantViewer) {
     return variantViewer.width - 20;
-}
+};
 
 var getAxisLength = function(variantViewer) {
     return variantViewer.width - 18;
-}
+};
 
 var createDataSeries = function(fv, variantViewer, features, series) {
     var mainChart = variantViewer.svg.append('g')

--- a/src/VariantViewer.js
+++ b/src/VariantViewer.js
@@ -160,8 +160,29 @@ var drawVariants = function(variantViewer, bars, frequency, fv, container, catTi
     variantCircle.exit().remove();
 };
 
-var createDataSeries = function(fv, variantViewer, svg, features, series) {
-    var mainChart = svg.append('g')
+
+var updateChartArea = function(variantViewer){
+    variantViewer.svg.select('#plotAreaClip rect')
+        .attr("width", function(){return getClipPathWidth(variantViewer)});
+
+    variantViewer.svg.selectAll('.variation-y.axis.left line')
+        .attr('x2', getAxisLength(variantViewer));
+
+    variantViewer.svg.selectAll('.variation-y.axis.right')
+        .attr('transform','translate(' + getAxisLength(variantViewer) + ', 0)');
+
+}
+
+var getClipPathWidth = function(variantViewer) {
+    return variantViewer.width - 20;
+}
+
+var getAxisLength = function(variantViewer) {
+    return variantViewer.width - 18;
+}
+
+var createDataSeries = function(fv, variantViewer, features, series) {
+    var mainChart = variantViewer.svg.append('g')
         .attr('transform','translate(0,' + variantViewer.margin.top + ')');
 
     var chartArea = mainChart.append('g')
@@ -170,7 +191,7 @@ var createDataSeries = function(fv, variantViewer, svg, features, series) {
     mainChart.append('clipPath')
         .attr('id', 'plotAreaClip')
         .append('rect')
-        .attr({ width: (variantViewer.width -20) , height: variantViewer.height})
+        .attr({ width: (getClipPathWidth(variantViewer)) , height: variantViewer.height})
         .attr('transform','translate(10, -10)');
 
     var dataSeries = chartArea
@@ -188,12 +209,12 @@ var createDataSeries = function(fv, variantViewer, svg, features, series) {
 
     mainChart.append('g')
         .attr('transform','translate(12 ,0)')
-        .attr('class','variation-y axis')
+        .attr('class','variation-y axis left')
         .call(yAxis);
 
     mainChart.append('g')
-        .attr('transform','translate(' + (variantViewer.width - 18) + ', 0)')
-        .attr('class','variation-y axis')
+        .attr('transform','translate(' + getAxisLength(variantViewer) + ', 0)')
+        .attr('class','variation-y axis right')
         .call(yAxis2);
 
     fv.globalContainer.selectAll('g.variation-y g.tick').attr('class', function(d) {
@@ -274,16 +295,18 @@ var VariantViewer = function(catTitle, features, container, fv, variantHeight, t
         return variationPlot;
     };
 
-    var svg = ViewerHelper.createSVG(container, variantViewer.width, variantViewer.height, fv, 'up_pftv_variants-svg');
+    variantViewer.svg = ViewerHelper.createSVG(container, variantViewer.width, variantViewer.height, fv, 'up_pftv_variants-svg');
 
     // Data series
     var series = variationPlot()
         .xScale(variantViewer.xScale)
         .yScale(variantViewer.yScale);
 
-    var dataSeries = createDataSeries(fv, variantViewer, svg, features, series);
+    var dataSeries = createDataSeries(fv, variantViewer, features, series);
 
     this.update = function() {
+        variantViewer.width = fv.width;
+        updateChartArea(variantViewer);
         dataSeries.call(series);
         if (fv.selectedFeature) {
             ViewerHelper.updateHighlight(fv);

--- a/src/ViewerHelper.js
+++ b/src/ViewerHelper.js
@@ -14,8 +14,8 @@ var ViewerHelper = function() {
                 .append('svg')
                 .attr('width', '100%')
                 .attr('height', height)
-                .attr('viewBox', function(){return "0,0," + width + "," + height;})
-                .attr('preserveAspectRatio', 'none')
+                // .attr('viewBox', function(){return "0,0," + width + "," + height;})
+                // .attr('preserveAspectRatio', 'none')
                 .on('mousedown', function() {
                     mousedownXY = {x: d3.event.pageX, y: d3.event.pageY};
                     mouseupXY = {x: -2, y: -2};

--- a/src/ViewerHelper.js
+++ b/src/ViewerHelper.js
@@ -15,6 +15,7 @@ var ViewerHelper = function() {
                 .attr('width', '100%')
                 .attr('height', height)
                 .attr('viewBox', function(){return "0,0," + width + "," + height;})
+                .attr('preserveAspectRatio', 'none')
                 .on('mousedown', function() {
                     mousedownXY = {x: d3.event.pageX, y: d3.event.pageY};
                     mouseupXY = {x: -2, y: -2};

--- a/src/ViewerHelper.js
+++ b/src/ViewerHelper.js
@@ -12,8 +12,9 @@ var ViewerHelper = function() {
         createSVG: function(container, width, height, fv, clazz) {
             var svg = container
                 .append('svg')
-                .attr('width', width)
+                .attr('width', '100%')
                 .attr('height', height)
+                .attr('viewBox', function(){return "0,0," + width + "," + height;})
                 .on('mousedown', function() {
                     mousedownXY = {x: d3.event.pageX, y: d3.event.pageY};
                     mouseupXY = {x: -2, y: -2};

--- a/style/main.css
+++ b/style/main.css
@@ -212,6 +212,10 @@ svg {
     stroke: black;
 }
 
+.up_pftv_aaviewer path {
+    display: none;
+}
+
 .up_pftv_navruler .up_pftv_viewport {
     fill: #D7DCE0;
     fill-opacity: 0.4;

--- a/style/main.css
+++ b/style/main.css
@@ -110,7 +110,7 @@ svg {
     line-height: 2.1em;
     width: 180px;
     vertical-align: bottom;
-    padding: .485em;
+    padding: .5em;
     border: none;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/style/main.css
+++ b/style/main.css
@@ -213,7 +213,7 @@ svg {
 }
 
 .up_pftv_aaviewer path {
-    display: none;
+    display: no;
 }
 
 .up_pftv_navruler .up_pftv_viewport {

--- a/style/main.css
+++ b/style/main.css
@@ -3,7 +3,7 @@ svg {
 }
 
 .up_pftv_buttons {
-    display: inline-block;
+    display: table-cell;
     padding: 0 .5em 0 .5em;
     width: 180px;
     text-align: right;
@@ -11,8 +11,13 @@ svg {
     position: relative;
 }
 
+.bottom-aa-container {
+    display: table;
+    width: 100%;
+}
+
 .up_pftv_credit_container {
-  display: inline-block;
+  display: table-cell;
   vertical-align: top;
   width: 180px;
   padding: 0 0.5em;
@@ -45,7 +50,7 @@ svg {
 
 .up_pftv_container {
     position: relative;
-    width: 960px;
+    /*width: 960px;*/
     color:#557071 !important;
     font-family: 'Helvetica neue', Helvetica, Arial, sans-serif !important;
     font-size: 13px !important;
@@ -96,12 +101,13 @@ svg {
 .up_pftv_category {
     margin-bottom: .1em;
     border-bottom: .1em solid #b2f5ff;
+    display: table;
+    width: 100%;
 }
 
 .up_pftv_category-name, .up_pftv_track-header {
     font-weight: 400;
     line-height: 2.1em;
-    display: inline-block;
     width: 180px;
     vertical-align: bottom;
     padding: .485em;
@@ -113,6 +119,8 @@ svg {
 
 .up_pftv_category-name {
     background-color: #b2f5ff;
+    display: table-cell;
+
 }
 
 .up_pftv_category a:hover {
@@ -122,6 +130,7 @@ svg {
 }
 
 .up_pftv_track-header {
+    display: table-cell;
     background-color: #d9faff;
     /*line-height: 1.6em;
     margin: .05em 0;*/
@@ -129,9 +138,19 @@ svg {
 
 .up_pftv_category-viewer, .up_pftv_track, .up_pftv_aaviewer {
     position: relative;
-    display: inline-block;
     vertical-align: bottom;
-    width: 760px;
+    /*width: 760px;*/
+}
+.up_pftv_track {
+    display: table-cell;
+}
+
+.up_pftv_aaviewer {
+    display: table-cell;
+}
+
+.up_pftv_category-viewer {
+    display: table-cell;
 }
 
 .up_pftv_category-viewer svg, .up_pftv_track svg, .up_pftv_aaviewer svg {
@@ -146,6 +165,10 @@ svg {
     vertical-align: top;
     margin-top: 1px;
     background-color: #D9FAFF;
+}
+
+.up_pftv_category-tracks {
+    display: table-row;
 }
 
 .up_pftv_track {
@@ -782,4 +805,8 @@ a.up_pftv_icon-button:hover {
 
 .up_pftv_icon-info {
     background: url(../SVG/info.svg);
+}
+
+.up_pftv-clear {
+    clear:both;
 }


### PR DESCRIPTION
I implemented scaling of ProtVista so that it can be used as a responsive component with a varying width (which I needed in one project). In the _example.html_, one can find how it can be used either with fixed or dynamic width.

All the SVGs now take 100% width of their parent elements and when the component changes its size, scales in the individual components (BasicViewer, CategoryViewer, viewport) change accordingly and update of the position and length of all the elements is triggered. 

To have SVGs 100% of the space right of categories names, I enclosed the rows into a div with the display set to _table_. So category names and tracks are now distinct cells of one row. This enables dynamic resize of the SVGs when the component changes its size.