### PR TITLE
Allows to have html description

### DIFF
--- a/src/TooltipFactory.js
+++ b/src/TooltipFactory.js
@@ -124,7 +124,7 @@ var addDescription = function(tooltip, description) {
     if (description) {
         var dataDes = tooltip.table.append('tr');
         dataDes.append('td').text('Description');
-        dataDes.append('td').text(description);
+        dataDes.append('td').html(description);
     }
 };
 


### PR DESCRIPTION
As it is presented as an optional string in http://ebi-uniprot.github.io/ProtVista/developerGuide.html#basic-visualization, could we have it as a optional html-string ?